### PR TITLE
[fix] - 로그인 -> access token(기존) / refresh token(추가) 구현

### DIFF
--- a/src/main/java/com/example/reviewmate/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/reviewmate/domain/user/controller/AuthController.java
@@ -1,13 +1,17 @@
 package com.example.reviewmate.domain.user.controller;
 
 import com.example.reviewmate.domain.user.dto.AuthorizeUser;
+import com.example.reviewmate.domain.user.service.AuthUpdateService;
+import com.example.reviewmate.jwt.RefreshTokenRepository;
 import com.example.reviewmate.jwt.TokenProvider;
+import com.example.reviewmate.jwt.dto.TokenDTO;
+import com.example.reviewmate.jwt.dto.TokenRequestDTO;
+import com.example.reviewmate.jwt.entity.RefreshTokenVO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,12 +23,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final TokenProvider tokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthUpdateService authUpdateService;
 
-
-    public AuthController(TokenProvider tokenProvider, AuthenticationManagerBuilder authenticationManagerBuilder) {
+    public AuthController(TokenProvider tokenProvider, AuthenticationManagerBuilder authenticationManagerBuilder, RefreshTokenRepository refreshTokenRepository, AuthUpdateService authUpdateService) {
         this.tokenProvider = tokenProvider;
         this.authenticationManagerBuilder = authenticationManagerBuilder;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.authUpdateService = authUpdateService;
     }
+
 
     @PostMapping("/v1/user/authentication") // login과정
     public ResponseEntity<AuthorizeUser.Response> authorize(
@@ -39,10 +47,24 @@ public class AuthController {
         //인증성공후 Authentication 인증객체를 만들어서 내부의 Principal, Credentials을 채워넣는다.
         // 이후 SecurityContextHolder 객체안의 SecurityContext에 저장 -> 인증객체를 전역적으로 사용가능능
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        //SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        String jwt = tokenProvider.createToken(authentication);
+        TokenDTO tokenDTO = tokenProvider.createToken(authentication);
 
-        return new ResponseEntity<>(new AuthorizeUser.Response(jwt), HttpStatus.OK);
+        RefreshTokenVO refreshToken = RefreshTokenVO.builder()
+                .key(authentication.getName())
+                .value(tokenDTO.getRefreshToken())
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+
+        return new ResponseEntity<>(new AuthorizeUser.Response(tokenDTO), HttpStatus.OK);
     }
+
+    @PostMapping("/v1/user/reissue")
+    public ResponseEntity<TokenDTO>reissue(@RequestBody TokenRequestDTO request){
+        return ResponseEntity.ok(authUpdateService.reissue(request));
+    }
+
+
 }

--- a/src/main/java/com/example/reviewmate/domain/user/dto/AuthorizeUser.java
+++ b/src/main/java/com/example/reviewmate/domain/user/dto/AuthorizeUser.java
@@ -1,5 +1,6 @@
 package com.example.reviewmate.domain.user.dto;
 
+import com.example.reviewmate.jwt.dto.TokenDTO;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -22,6 +23,6 @@ public class AuthorizeUser {
     @AllArgsConstructor
     @Getter
     public static class Response{
-        String jwt;
+       TokenDTO tokenDTO;
     }
 }

--- a/src/main/java/com/example/reviewmate/domain/user/service/AuthUpdateService.java
+++ b/src/main/java/com/example/reviewmate/domain/user/service/AuthUpdateService.java
@@ -1,0 +1,59 @@
+package com.example.reviewmate.domain.user.service;
+
+import com.example.reviewmate.domain.user.repository.UserRepository;
+import com.example.reviewmate.jwt.RefreshTokenRepository;
+import com.example.reviewmate.jwt.TokenProvider;
+import com.example.reviewmate.jwt.dto.TokenDTO;
+import com.example.reviewmate.jwt.dto.TokenRequestDTO;
+import com.example.reviewmate.jwt.entity.RefreshTokenVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthUpdateService {
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private  final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public AuthUpdateService(AuthenticationManagerBuilder authenticationManagerBuilder, UserRepository userRepository, PasswordEncoder passwordEncoder, TokenProvider tokenProvider, RefreshTokenRepository refreshTokenRepository) {
+        this.authenticationManagerBuilder = authenticationManagerBuilder;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.tokenProvider = tokenProvider;
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @Transactional
+    public TokenDTO reissue(TokenRequestDTO request){
+        if(!tokenProvider.validateToken(request.getRefreshToken()))
+        {
+        throw new RuntimeException("refresh token이 유효하지 않습니다.");
+
+        }
+
+        Authentication authentication = tokenProvider.getAuthentication(request.getAccessToken());
+
+        RefreshTokenVO refreshTokenVO = refreshTokenRepository.findByKey(authentication.getName())
+                .orElseThrow(()->new RuntimeException("로그아웃된 사용자입니다."));
+
+        if(!refreshTokenVO.getValue().equals(request.getRefreshToken())){
+            throw new RuntimeException("토큰의 유저 정보가 일치 하지 않습니다.");
+        }
+
+        TokenDTO tokenDto = tokenProvider.createToken(authentication);
+
+        RefreshTokenVO refreshToken = refreshTokenVO.updateValue(tokenDto.getRefreshToken());
+        refreshTokenRepository.save(refreshToken);
+
+        return tokenDto;
+
+    }
+
+
+}

--- a/src/main/java/com/example/reviewmate/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/example/reviewmate/jwt/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.example.reviewmate.jwt;
+
+import com.example.reviewmate.jwt.entity.RefreshTokenVO;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenVO,Long> {
+    Optional<RefreshTokenVO> findByKey(String key);
+}

--- a/src/main/java/com/example/reviewmate/jwt/dto/TokenDTO.java
+++ b/src/main/java/com/example/reviewmate/jwt/dto/TokenDTO.java
@@ -1,0 +1,26 @@
+package com.example.reviewmate.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+
+public class TokenDTO {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+
+    @Builder
+    public TokenDTO(String grantType, String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+        this.grantType = grantType;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
+    }
+
+}

--- a/src/main/java/com/example/reviewmate/jwt/dto/TokenRequestDTO.java
+++ b/src/main/java/com/example/reviewmate/jwt/dto/TokenRequestDTO.java
@@ -1,0 +1,14 @@
+package com.example.reviewmate.jwt.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRequestDTO {
+
+        private String accessToken;
+        private String refreshToken;
+
+}

--- a/src/main/java/com/example/reviewmate/jwt/entity/RefreshTokenVO.java
+++ b/src/main/java/com/example/reviewmate/jwt/entity/RefreshTokenVO.java
@@ -1,0 +1,35 @@
+package com.example.reviewmate.jwt.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Getter
+@NoArgsConstructor
+@Table(name = "REFRESH_TOKEN_TB")
+@Entity
+public class RefreshTokenVO {
+
+    @Id
+    @Column(name = "rt_key")
+    private String key;
+
+    @Column(name = "rt_value")
+    private String value;
+
+    @Builder
+    public RefreshTokenVO(String key, String value){
+        this.key = key;
+        this.value = value;
+    }
+
+    public RefreshTokenVO updateValue(String token){
+        this.value = token;
+        return this;
+    }
+}


### PR DESCRIPTION
기존 : access token 이용하여 로그인 인증 로직 구현
수정  :  refresh token 이용하여 access token 재발급